### PR TITLE
Format Python code with isort & Black Code Formatter

### DIFF
--- a/custom_components/nws_alerts_array/__init__.py
+++ b/custom_components/nws_alerts_array/__init__.py
@@ -5,29 +5,26 @@ from datetime import timedelta
 import aiohttp
 from async_timeout import timeout
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import (
-    async_entries_for_config_entry,
-    async_get,
-)
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.entity_registry import async_entries_for_config_entry
+from homeassistant.helpers.entity_registry import async_get
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .const import (
-    API_ENDPOINT,
-    CONF_INTERVAL,
-    CONF_TIMEOUT,
-    CONF_ZONE_ID,
-    COORDINATOR,
-    DEFAULT_INTERVAL,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-    ISSUE_URL,
-    PLATFORMS,
-    USER_AGENT,
-    VERSION,
-)
+from .const import API_ENDPOINT
+from .const import CONF_INTERVAL
+from .const import CONF_TIMEOUT
+from .const import CONF_ZONE_ID
+from .const import COORDINATOR
+from .const import DEFAULT_INTERVAL
+from .const import DEFAULT_TIMEOUT
+from .const import DOMAIN
+from .const import ISSUE_URL
+from .const import PLATFORMS
+from .const import USER_AGENT
+from .const import VERSION
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/nws_alerts_array/config_flow.py
+++ b/custom_components/nws_alerts_array/config_flow.py
@@ -11,17 +11,15 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import (
-    API_ENDPOINT,
-    CONF_INTERVAL,
-    CONF_TIMEOUT,
-    CONF_ZONE_ID,
-    DEFAULT_INTERVAL,
-    DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-    USER_AGENT,
-)
+from .const import API_ENDPOINT
+from .const import CONF_INTERVAL
+from .const import CONF_TIMEOUT
+from .const import CONF_ZONE_ID
+from .const import DEFAULT_INTERVAL
+from .const import DEFAULT_NAME
+from .const import DEFAULT_TIMEOUT
+from .const import DOMAIN
+from .const import USER_AGENT
 
 JSON_FEATURES = "features"
 JSON_PROPERTIES = "properties"

--- a/custom_components/nws_alerts_array/sensor.py
+++ b/custom_components/nws_alerts_array/sensor.py
@@ -3,26 +3,26 @@ import uuid
 
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
-from . import AlertsDataUpdateCoordinator
 
-from .const import (
-    ATTRIBUTION,
-    CONF_INTERVAL,
-    CONF_TIMEOUT,
-    CONF_ZONE_ID,
-    COORDINATOR,
-    DEFAULT_ICON,
-    DEFAULT_INTERVAL,
-    DEFAULT_NAME,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-)
+from . import AlertsDataUpdateCoordinator
+from .const import ATTRIBUTION
+from .const import CONF_INTERVAL
+from .const import CONF_TIMEOUT
+from .const import CONF_ZONE_ID
+from .const import COORDINATOR
+from .const import DEFAULT_ICON
+from .const import DEFAULT_INTERVAL
+from .const import DEFAULT_NAME
+from .const import DEFAULT_TIMEOUT
+from .const import DOMAIN
 
 # ---------------------------------------------------------
 # API Documentation


### PR DESCRIPTION
There appear to be some python formatting errors in 84e0f2e2e5c4c882c8fbc4969ec55542886a69df. This pull request
uses the [Black Code Formatter](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort) to fix these issues.